### PR TITLE
sync from origin-v2: richer git-notes context for cross-agent handoff (0.20260508.1613)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origin/cli",
-  "version": "0.20260508.2257",
+  "version": "0.20260508.1613",
   "type": "module",
   "bin": {
     "origin": "./dist/index.js"

--- a/src/acceptance.ts
+++ b/src/acceptance.ts
@@ -1,0 +1,244 @@
+// Acceptance backfill: after a session finishes, look at the *previous*
+// session's commits and measure how many of those AI-added lines still exist
+// on HEAD. This answers "did the human keep the prior agent's output, or
+// override it?" — gold for the next agent reading blame.
+//
+// Stored in a separate ref (refs/notes/origin-acceptance) so we never mutate
+// the original session's note. Same push semantics as refs/notes/origin.
+
+import { execFileSync } from 'child_process';
+
+const ACCEPTANCE_REF = 'refs/notes/origin-acceptance';
+
+export interface AcceptanceNote {
+  version: 1;
+  sessionId: string;
+  computedAt: string;
+  // AI lines added by this commit (per `git diff-tree`).
+  addedLines: number;
+  // AI lines still present on HEAD per `git blame` (i.e., not overwritten).
+  survivingLines: number;
+  // survivingLines / addedLines, rounded to 2 decimals. 0..1.
+  acceptanceRate: number;
+}
+
+const execOpts = (cwd: string) => ({
+  cwd,
+  encoding: 'utf-8' as const,
+  stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe'],
+  maxBuffer: 10 * 1024 * 1024,
+  timeout: 15000,
+});
+
+// Files added by `commitSha` and the line ranges that commit added in each
+// file's post-commit numbering. Returns null when diff-tree fails (e.g. root
+// commit, broken refs).
+function getAddedLineRanges(
+  repoPath: string,
+  commitSha: string,
+): Array<{ file: string; lines: number[] }> | null {
+  let diff: string;
+  try {
+    diff = execFileSync(
+      'git',
+      ['diff-tree', '-p', '--no-color', '-M', '-C', commitSha],
+      execOpts(repoPath),
+    );
+  } catch {
+    return null;
+  }
+
+  const out: Array<{ file: string; lines: number[] }> = [];
+  let currentFile = '';
+  let currentLines: number[] = [];
+  let lineNum = 0;
+
+  const flush = () => {
+    if (currentFile && currentLines.length) {
+      out.push({ file: currentFile, lines: currentLines });
+    }
+    currentFile = '';
+    currentLines = [];
+    lineNum = 0;
+  };
+
+  for (const line of diff.split('\n')) {
+    const fileMatch = line.match(/^\+\+\+ b\/(.*)$/);
+    if (fileMatch) {
+      flush();
+      currentFile = fileMatch[1];
+      continue;
+    }
+    if (line.startsWith('--- ')) continue;
+    const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)/);
+    if (hunkMatch) {
+      lineNum = parseInt(hunkMatch[1], 10);
+      continue;
+    }
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      currentLines.push(lineNum);
+      lineNum++;
+    } else if (line.startsWith('-')) {
+      // deletion — don't advance post-commit line counter
+    } else if (!line.startsWith('\\')) {
+      lineNum++;
+    }
+  }
+  flush();
+  return out;
+}
+
+// For each (file, line) added by `commitSha`, check whether that line is
+// still attributed to `commitSha` on HEAD. If yes, it survived. If the file
+// was deleted or the line was overwritten, blame returns a different SHA.
+function countSurviving(
+  repoPath: string,
+  commitSha: string,
+  added: Array<{ file: string; lines: number[] }>,
+): number {
+  let surviving = 0;
+  for (const { file, lines } of added) {
+    if (!lines.length) continue;
+    let blame: string;
+    try {
+      blame = execFileSync(
+        'git',
+        ['blame', '--porcelain', 'HEAD', '--', file],
+        execOpts(repoPath),
+      );
+    } catch {
+      // File deleted or unblameable — none of these lines survived.
+      continue;
+    }
+    // Build line -> sha map. Porcelain header is `<sha> <orig> <final> [<n>]`.
+    // Following lines until the content tab carry metadata. We only need sha
+    // per final line, so we map header SHA to its `final` line number.
+    const lineToSha = new Map<number, string>();
+    for (const raw of blame.split('\n')) {
+      const m = raw.match(/^([0-9a-f]{40})\s+\d+\s+(\d+)/);
+      if (m) {
+        lineToSha.set(parseInt(m[2], 10), m[1]);
+      }
+    }
+    for (const ln of lines) {
+      if (lineToSha.get(ln) === commitSha) surviving++;
+    }
+  }
+  return surviving;
+}
+
+export function computeCommitAcceptance(
+  repoPath: string,
+  commitSha: string,
+): { addedLines: number; survivingLines: number } {
+  const added = getAddedLineRanges(repoPath, commitSha);
+  if (!added) return { addedLines: 0, survivingLines: 0 };
+  const addedLines = added.reduce((sum, f) => sum + f.lines.length, 0);
+  if (addedLines === 0) return { addedLines: 0, survivingLines: 0 };
+  const survivingLines = countSurviving(repoPath, commitSha, added);
+  return { addedLines, survivingLines };
+}
+
+export function writeAcceptanceNote(
+  repoPath: string,
+  commitSha: string,
+  note: AcceptanceNote,
+): void {
+  try {
+    execFileSync(
+      'git',
+      ['notes', `--ref=${ACCEPTANCE_REF.replace('refs/notes/', '')}`, 'add', '-f', '-m', JSON.stringify(note, null, 2), commitSha],
+      execOpts(repoPath),
+    );
+  } catch {
+    // Non-fatal: acceptance is a nice-to-have.
+  }
+}
+
+export function readAcceptanceNote(
+  repoPath: string,
+  commitSha: string,
+): AcceptanceNote | null {
+  try {
+    const raw = execFileSync(
+      'git',
+      ['notes', `--ref=origin-acceptance`, 'show', commitSha],
+      execOpts(repoPath),
+    ).trim();
+    const parsed = JSON.parse(raw);
+    if (parsed?.version === 1) return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Find commits in the recent history that belong to `sessionId` (per their
+// origin note) and write an acceptance note for each. Bounded both by commit
+// scan window and per-session commit count to keep session-end snappy on
+// repos with hot files (each commit triggers a `git blame` per touched file).
+//
+// Optionally pass `sinceIso` (the previous session's startedAt) to scope the
+// scan to commits the prior session could have authored — much cheaper than
+// reading notes on every recent commit.
+export function backfillAcceptanceForSession(
+  repoPath: string,
+  sessionId: string,
+  opts: { scanLimit?: number; maxCommits?: number; sinceIso?: string } = {},
+): number {
+  if (!sessionId || sessionId === 'unknown' || sessionId.startsWith('local-')) {
+    return 0;
+  }
+  const scanLimit = opts.scanLimit ?? 50;
+  const maxCommits = opts.maxCommits ?? 20;
+
+  let shas: string[];
+  try {
+    const args = ['log', `-n${scanLimit}`, '--format=%H'];
+    if (opts.sinceIso) args.push(`--since=${opts.sinceIso}`);
+    args.push('HEAD');
+    shas = execFileSync('git', args, execOpts(repoPath))
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+  } catch {
+    return 0;
+  }
+
+  // First pass: cheaply collect this session's commits without doing any
+  // blame work. If the session touched too many commits, skip backfill —
+  // running blame across all of them would block agent shutdown.
+  const sessionCommits: string[] = [];
+  for (const sha of shas) {
+    let note: any = null;
+    try {
+      const raw = execFileSync(
+        'git',
+        ['notes', '--ref=origin', 'show', sha],
+        execOpts(repoPath),
+      ).trim();
+      note = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    const noteSession = note?.origin?.sessionId || note?.sessionId;
+    if (noteSession === sessionId) sessionCommits.push(sha);
+    if (sessionCommits.length > maxCommits) return 0;
+  }
+
+  let written = 0;
+  for (const sha of sessionCommits) {
+    const { addedLines, survivingLines } = computeCommitAcceptance(repoPath, sha);
+    if (addedLines === 0) continue;
+    writeAcceptanceNote(repoPath, sha, {
+      version: 1,
+      sessionId,
+      computedAt: new Date().toISOString(),
+      addedLines,
+      survivingLines,
+      acceptanceRate: Math.round((survivingLines / addedLines) * 100) / 100,
+    });
+    written++;
+  }
+  return written;
+}

--- a/src/attribution.ts
+++ b/src/attribution.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'child_process';
 import { listActiveSessions } from './session-state.js';
+import { readAcceptanceNote } from './acceptance.js';
 
 // ─── Tool Detection ──────────────────────────────────────────────────────
 
@@ -32,6 +33,7 @@ export interface LineAttribution {
   model?: string;
   author?: string;
   tool?: string;
+  commitSha?: string;
 }
 
 export interface FileAttribution {
@@ -242,6 +244,48 @@ function detectAiFromCommit(repoPath: string, commitSha: string): { isAi: boolea
   }
 }
 
+// Rich session context surfaced from per-commit origin notes — used by
+// `origin blame --json` so consumers can answer "what was the prior agent
+// trying to do here?" without having to parse git notes themselves.
+export interface SessionContext {
+  sessionId: string;
+  model?: string;
+  agent?: string;
+  fullPrompt?: string;
+  promptSummary?: string;
+  previousSessionId?: string;
+  filesRead?: string[];
+  // Fraction (0..1) of this session's added lines still present on HEAD.
+  // Sourced from refs/notes/origin-acceptance, written by the *next* session.
+  acceptanceRate?: number;
+  acceptanceComputedAt?: string;
+  originUrl?: string;
+}
+
+export function getSessionContextForCommit(
+  repoPath: string,
+  commitSha: string,
+): SessionContext | null {
+  const rawNote = readOriginNote(repoPath, commitSha);
+  const note = rawNote?.origin || rawNote;
+  if (!note?.sessionId) return null;
+
+  const acc = readAcceptanceNote(repoPath, commitSha);
+
+  return {
+    sessionId: note.sessionId,
+    model: note.model,
+    agent: note.agent,
+    fullPrompt: note.fullPrompt,
+    promptSummary: note.promptSummary,
+    previousSessionId: note.previousSessionId,
+    filesRead: Array.isArray(note.filesRead) ? note.filesRead : undefined,
+    acceptanceRate: acc?.acceptanceRate,
+    acceptanceComputedAt: acc?.computedAt,
+    originUrl: note.originUrl,
+  };
+}
+
 /**
  * Get line-level AI attribution for a file by cross-referencing git blame with origin notes.
  * Falls back to commit message trailer detection and AI process pattern matching.
@@ -294,6 +338,7 @@ export function getLineBlame(repoPath: string, filePath: string): LineAttributio
         model: model,
         tool: tool,
         author: author,
+        commitSha: commitSha,
       };
     });
   } catch {

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -1,10 +1,10 @@
 // AUTO-GENERATED at build time by scripts/write-build-info.cjs.
 // Do not edit by hand. This file is gitignored.
 export const BUILD_INFO = {
-  "version": "0.20260508.2257",
-  "gitSha": "6f230ed37e792d2e6b7497910f39a6e387484ca0",
-  "gitShortSha": "6f230ed37e79",
-  "gitBranch": "main",
+  "version": "0.20260508.1613",
+  "gitSha": "efc1e83d2f43f8549e27c66714e59cf90d8399ec",
+  "gitShortSha": "efc1e83d2f43",
+  "gitBranch": "sync-rich-context-notes",
   "gitDirty": true,
-  "builtAt": "2026-05-08T02:57:32.719Z"
+  "builtAt": "2026-05-08T20:14:05.364Z"
 } as const;

--- a/src/commands/blame.ts
+++ b/src/commands/blame.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
-import { getLineBlame } from '../attribution.js';
+import { getLineBlame, getSessionContextForCommit, type SessionContext } from '../attribution.js';
 import { getGitRoot } from '../session-state.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────
@@ -108,9 +108,21 @@ export async function blameCommand(
     return;
   }
 
-  // JSON output
+  // JSON output — emit a sessions map keyed by sessionId so callers can look
+  // up the rich context (full prompt, previousSessionId, filesRead, acceptance)
+  // once per session instead of per line.
   if (opts?.json) {
-    console.log(JSON.stringify(filtered, null, 2));
+    const sessions: Record<string, SessionContext> = {};
+    const seenCommits = new Set<string>();
+    for (const attr of attributions) {
+      if (!attr.commitSha || !attr.sessionId || seenCommits.has(attr.commitSha)) continue;
+      seenCommits.add(attr.commitSha);
+      const ctx = getSessionContextForCommit(repoPath, attr.commitSha);
+      if (ctx && !sessions[ctx.sessionId]) {
+        sessions[ctx.sessionId] = ctx;
+      }
+    }
+    console.log(JSON.stringify({ file, lines: filtered, sessions }, null, 2));
     return;
   }
 

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -30,7 +30,8 @@ import { redactSecrets } from '../redaction.js';
 import { findTrailByBranch, addSessionToTrail } from '../trail-state.js';
 import { buildAttributionContext, buildFileAttributionContext } from '../attribution.js';
 import { writeHandoff, buildHandoffContext, extractTodosFromPrompts } from '../handoff.js';
-import { writeSessionMemory, buildMemoryContext } from '../memory.js';
+import { writeSessionMemory, buildMemoryContext, readRecentMemory } from '../memory.js';
+import { backfillAcceptanceForSession } from '../acceptance.js';
 import { addTodosFromSession } from '../todo.js';
 import { createSnapshot, condenseSnapshot, listSnapshots, condenseAndCleanupSession, cleanupSessionShadowBranch, type SnapshotMeta } from './snapshot.js';
 import { execFileSync } from 'child_process';
@@ -1825,6 +1826,22 @@ async function handleSessionStart(input: Record<string, any>, agentSlug?: string
       debugLog('session-start', 'standalone session', { sessionId });
     }
 
+    // Look up the most recent session in this repo so we can record a
+    // previousSessionId pointer in this session's git notes. Lets future
+    // agents walk the chain of sessions across commits. We also stash the
+    // prior session's startedAt so the acceptance backfill at session-end
+    // can scope its commit scan instead of reading notes on every recent
+    // commit in the repo.
+    let previousSessionId: string | undefined;
+    let previousSessionStartedAt: string | undefined;
+    try {
+      const recent = readRecentMemory(repoPath, 1);
+      if (recent.length > 0 && recent[0].sessionId && recent[0].sessionId !== sessionId) {
+        previousSessionId = recent[0].sessionId;
+        previousSessionStartedAt = recent[0].startedAt;
+      }
+    } catch { /* non-fatal */ }
+
     const state: SessionState = {
       sessionId,
       claudeSessionId,
@@ -1844,6 +1861,8 @@ async function handleSessionStart(input: Record<string, any>, agentSlug?: string
       activePolicies,
       enforcementRules,
       verboseCapture,
+      previousSessionId,
+      previousSessionStartedAt,
     };
 
     // Multi-repo: store all repo paths and per-repo git state
@@ -2915,9 +2934,12 @@ async function handleStop(input: Record<string, any>, agentSlug?: string): Promi
           writeGitNotes(state.repoPath, missingNotes, {
             sessionId: state.sessionId,
             model: model || state.model || 'unknown',
-            agentSlug: agentSlug || undefined,
+            agentSlug: agentSlug || state.agentSlug,
             promptCount: prompts.length,
             promptSummary: prompts[prompts.length - 1] || '',
+            fullPrompt: prompts[prompts.length - 1] || undefined,
+            previousSessionId: state.previousSessionId,
+            filesRead: state.filesRead,
             tokensUsed: parsed.tokensUsed,
             costUsd,
             durationMs: durationMs > 0 ? durationMs : 0,
@@ -3292,8 +3314,12 @@ async function handleSessionEnd(input: Record<string, any>, agentSlug?: string):
         writeGitNotes(state.repoPath, gitCapture.commitShas, {
           sessionId: state.sessionId,
           model,
+          agentSlug: agentSlug || state.agentSlug,
           promptCount: prompts.length,
           promptSummary: prompts[0] || '',
+          fullPrompt: prompts[prompts.length - 1] || prompts[0] || undefined,
+          previousSessionId: state.previousSessionId,
+          filesRead: state.filesRead,
           tokensUsed: parsed.tokensUsed,
           costUsd,
           durationMs,
@@ -3304,6 +3330,26 @@ async function handleSessionEnd(input: Record<string, any>, agentSlug?: string):
         debugLog('session-end', 'git notes written', { commitCount: gitCapture.commitShas.length });
       } catch (err: any) {
         debugLog('session-end', 'git notes error (non-fatal)', { message: err.message });
+      }
+    }
+
+    // Backfill acceptance for the *previous* session's commits. Now that
+    // this session has ended, any of the prior session's lines that were
+    // overwritten (or kept) here will be reflected. Writes to a separate
+    // ref (refs/notes/origin-acceptance) so original notes stay immutable.
+    if (state.previousSessionId) {
+      try {
+        const written = backfillAcceptanceForSession(state.repoPath, state.previousSessionId, {
+          sinceIso: state.previousSessionStartedAt,
+        });
+        if (written > 0) {
+          debugLog('session-end', 'acceptance backfill written', {
+            previousSessionId: state.previousSessionId,
+            commitsAnnotated: written,
+          });
+        }
+      } catch (err: any) {
+        debugLog('session-end', 'acceptance backfill error (non-fatal)', { message: err.message });
       }
     }
 
@@ -3699,8 +3745,12 @@ export async function handlePostCommit(): Promise<void> {
     writeGitNotes(repoPath, [commitSha], {
       sessionId: state?.sessionId || 'unknown',
       model: noteModel || 'unknown',
+      agentSlug: state?.agentSlug,
       promptCount: state?.prompts?.length || 0,
       promptSummary: state?.prompts?.[state.prompts.length - 1] || '',
+      fullPrompt: state?.prompts?.[state.prompts.length - 1] || undefined,
+      previousSessionId: state?.previousSessionId,
+      filesRead: state?.filesRead,
       tokensUsed: 0,
       costUsd: 0,
       durationMs: 0,
@@ -4034,7 +4084,9 @@ async function handlePreToolUse(input: Record<string, any>, agentSlug?: string):
   // When an agent reads or edits a file, inject per-file attribution so
   // the agent knows who wrote each part before modifying it.
   const toolName = (input.tool_name || '').toLowerCase();
-  if (['read', 'edit', 'write', 'view'].some(t => toolName.includes(t))) {
+  const isReadStyle = ['read', 'view', 'open', 'cat', 'grep', 'glob'].some(t => toolName.includes(t));
+  const isWriteStyle = ['edit', 'write', 'patch', 'create', 'insert', 'replace', 'notebook_edit'].some(t => toolName.includes(t));
+  if (isReadStyle || isWriteStyle) {
     const toolInput = input.tool_input || {};
     const filePath = toolInput.file_path || toolInput.path || toolInput.filePath || toolInput.filename || '';
     if (filePath && state.repoPath) {
@@ -4049,6 +4101,28 @@ async function handlePreToolUse(input: Record<string, any>, agentSlug?: string):
       } catch {
         // Non-fatal
       }
+    }
+  }
+
+  // ── Track files the agent has loaded into context ────────────────────────
+  // Persisted into git notes at session-end as `filesRead` so the next
+  // agent can see what the prior agent looked at, not just what it changed.
+  // Dedup on the *normalized* (repo-relative) form so we don't double-count
+  // when the same file is read via both absolute and relative paths across
+  // pre-tool-use invocations.
+  if (isReadStyle && filePaths.length > 0) {
+    if (!state.filesRead) state.filesRead = [];
+    const cap = 100;
+    const seen = new Set(state.filesRead);
+    for (const fp of filePaths) {
+      if (!fp) continue;
+      const rel = state.repoPath && fp.startsWith(state.repoPath + '/')
+        ? fp.slice(state.repoPath.length + 1)
+        : fp;
+      if (seen.has(rel)) continue;
+      state.filesRead.push(rel);
+      seen.add(rel);
+      if (state.filesRead.length >= cap) break;
     }
   }
 

--- a/src/git-notes.ts
+++ b/src/git-notes.ts
@@ -1,4 +1,23 @@
 import { execFileSync } from 'child_process';
+import { redactSecrets } from './redaction.js';
+
+function redact(text: string): string {
+  return redactSecrets(text || '').redacted;
+}
+
+const TRUNCATED_MARKER = '…[truncated]';
+
+function redactAndCap(text: string, maxBytes: number): string {
+  const out = redact(text);
+  const buf = Buffer.from(out, 'utf-8');
+  if (buf.length <= maxBytes) return out;
+  // Slice on byte boundaries, then re-decode. `Buffer.toString('utf-8')`
+  // replaces partial multi-byte sequences with U+FFFD, so we don't emit
+  // invalid UTF-8 even when the cap lands mid-codepoint.
+  const markerBytes = Buffer.byteLength(TRUNCATED_MARKER, 'utf-8');
+  const head = buf.subarray(0, Math.max(0, maxBytes - markerBytes)).toString('utf-8');
+  return head + TRUNCATED_MARKER;
+}
 
 /**
  * Write Origin metadata as Git Notes on each commit SHA.
@@ -11,12 +30,30 @@ import { execFileSync } from 'child_process';
  *   git notes --ref=origin show <SHA>
  */
 
+// Caps keep the per-commit note small enough to push without bloating the repo.
+// fullPrompt is the largest contributor; 8KB after redaction is a reasonable
+// budget for next-agent context (≈1500 tokens of preceding intent).
+const FULL_PROMPT_MAX_BYTES = 8 * 1024;
+const FILES_READ_MAX = 100;
+
 export interface GitNoteData {
   sessionId: string;
   model: string;
   agentSlug?: string;
   promptCount: number;
   promptSummary: string;
+  // Untruncated last prompt (post-redaction, capped at ~8KB). Lets the next
+  // agent reading blame see the actual intent behind a commit, not a 200-char
+  // teaser. Stored separately from promptSummary so older readers keep working.
+  fullPrompt?: string;
+  // Pointer to the previous Origin session in this repo, captured at
+  // session-start from refs/notes/origin-memory. Lets readers walk a chain of
+  // sessions to reconstruct evolution of a feature across commits.
+  previousSessionId?: string;
+  // Files the agent loaded into context during this session (unique paths,
+  // capped). Helps the next agent understand what the prior agent saw —
+  // not just what it changed.
+  filesRead?: string[];
   tokensUsed: number;
   costUsd: number;
   durationMs: number;
@@ -43,18 +80,31 @@ export function writeGitNotes(
     encoding: 'utf-8' as const,
   };
 
+  const summarySource = redact(data.promptSummary || '');
+  const promptSummary =
+    summarySource.length > 200 ? summarySource.slice(0, 200) + '...' : summarySource;
+  const fullPrompt = data.fullPrompt
+    ? redactAndCap(data.fullPrompt, FULL_PROMPT_MAX_BYTES)
+    : undefined;
+  const filesRead = data.filesRead && data.filesRead.length > 0
+    ? Array.from(new Set(data.filesRead)).slice(0, FILES_READ_MAX)
+    : undefined;
+
   const notePayload = JSON.stringify(
     {
       origin: {
+        // Stays at 1 — the new fields (fullPrompt, previousSessionId,
+        // filesRead) are purely additive. Existing readers look up keys
+        // by name and ignore unknowns, so no version bump is needed.
         version: 1,
         sessionId: data.sessionId,
         model: data.model,
         agent: data.agentSlug || undefined,
         promptCount: data.promptCount,
-        promptSummary:
-          data.promptSummary.length > 200
-            ? data.promptSummary.slice(0, 200) + '...'
-            : data.promptSummary,
+        promptSummary,
+        fullPrompt,
+        previousSessionId: data.previousSessionId || undefined,
+        filesRead,
         tokensUsed: data.tokensUsed,
         costUsd: parseFloat(data.costUsd.toFixed(4)),
         durationMs: data.durationMs,

--- a/src/session-state.ts
+++ b/src/session-state.ts
@@ -63,6 +63,18 @@ export interface SessionState {
   enforcementRules?: Array<{ type: string; condition: string; action: string; severity: string }>;
   trailId?: string;           // Trail ID if session is linked to an active trail
   agentSlug?: string;         // Agent slug (claude-code, cursor, codex, gemini, etc.)
+  // Files the agent loaded into context (deduped, capped). Populated lazily
+  // in pre-tool-use whenever a Read-style tool fires. Persisted into git
+  // notes at session-end as `filesRead` so the next agent can see what the
+  // prior agent looked at — not just what it changed.
+  filesRead?: string[];
+  // Pointer to the previous session in this repo (captured at session-start
+  // from refs/notes/origin-memory). Persisted into git notes so readers can
+  // walk a chain of sessions across commits.
+  previousSessionId?: string;
+  // ISO timestamp the previous session started — used to scope the
+  // acceptance backfill scan to only commits that session could have authored.
+  previousSessionStartedAt?: string;
   status?: string;            // RUNNING | ENDED | COMPLETED
   endedAt?: string;           // ISO timestamp when session ended
   // Multi-repo support: when cwd contains multiple git repos


### PR DESCRIPTION
## Summary

Mirrors [opsworks-co/origin#9](https://github.com/opsworks-co/origin/pull/9) (already merged on the monorepo side).

Per-commit git notes (\`refs/notes/origin\`) now ship enough context for the next agent — regardless of vendor — to pick up where the prior one left off, instead of just a 200-char prompt teaser.

Four new fields, all opt-in (existing readers ignore unknowns by name):

- **\`fullPrompt\`** — untruncated last prompt, run through the existing \`redactSecrets()\` engine, capped at 8KB
- **\`previousSessionId\`** — captured at session-start from \`refs/notes/origin-memory\`; lets readers walk session chains across commits
- **\`filesRead\`** — deduped repo-relative paths the agent loaded into context (cap 100), populated in pre-tool-use when a Read-style tool fires
- **Acceptance backfill** — at session-end, walks the *previous* session's commits and writes \`{addedLines, survivingLines, acceptanceRate}\` to a separate ref (\`refs/notes/origin-acceptance\`) so original notes stay immutable. Bounded by prior session's startedAt + caps at 50 commits scanned / 20 per-session.

\`origin blame --json\` now emits a per-session context map alongside the line array.

## Files changed

- \`src/git-notes.ts\` — extended \`GitNoteData\`, redaction + UTF-8-safe size caps applied on write
- \`src/acceptance.ts\` *(new)* — per-commit acceptance compute + \`refs/notes/origin-acceptance\` writer
- \`src/session-state.ts\` — \`filesRead\`, \`previousSessionId\`, \`previousSessionStartedAt\` on \`SessionState\`
- \`src/commands/hooks.ts\` — wires new fields through 3 \`writeGitNotes\` call sites; triggers acceptance backfill at session-end
- \`src/attribution.ts\` — \`LineAttribution.commitSha\`; new \`getSessionContextForCommit()\`
- \`src/commands/blame.ts\` — \`--json\` emits \`{ file, lines, sessions }\`

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — 238/238 pass
- [x] \`pnpm build\` — clean
- [ ] After publishing, run a session end-to-end on a real repo, inspect \`git notes --ref=origin show <sha>\` to confirm new fields land
- [ ] After a follow-up session, inspect \`git notes --ref=origin-acceptance show <prior-sha>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)