### PR TITLE
sync from origin-v2: drop AGENTS.md echo from Codex first turn (0.20260509.2039)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origin/cli",
-  "version": "0.20260508.1613",
+  "version": "0.20260509.2039",
   "type": "module",
   "bin": {
     "origin": "./dist/index.js"
@@ -23,12 +23,5 @@
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
     "vitest": "^4.0.18"
-  },
-  "pnpm": {
-    "overrides": {
-      "picomatch": ">=4.0.4",
-      "postcss": ">=8.5.10",
-      "vite": ">=8.0.5"
-    }
   }
 }

--- a/src/__tests__/prompt-cleanup.test.ts
+++ b/src/__tests__/prompt-cleanup.test.ts
@@ -1,0 +1,81 @@
+// Regression tests for the prompt-cleaner. Codex reads AGENTS.md natively
+// and re-emits its content as the first "user" turn in its rollout — that
+// envelope used to leak through and show up as a fake first prompt in the
+// dashboard. Verify both detection paths drop it.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { parseTranscript } from '../transcript.js';
+
+function writeJsonl(entries: any[]): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'origin-prompt-test-'));
+  const file = path.join(tmp, 'transcript.jsonl');
+  // Always end with a trailing newline + sentinel assistant entry — a single
+  // newline-free JSON entry would trip parseTranscript's single-object Gemini
+  // detection and skip the JSONL parser entirely.
+  const sentinel = { type: 'assistant', message: { role: 'assistant', content: '' } };
+  const all = [...entries, sentinel];
+  fs.writeFileSync(file, all.map(e => JSON.stringify(e)).join('\n') + '\n');
+  return file;
+}
+
+describe('cleanPrompt — system-injected envelope filtering', () => {
+  it('drops a user message that is just our origin-managed AGENTS.md echo', () => {
+    const file = writeJsonl([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: '# AGENTS.md instructions for /Users/me/repo <INSTRUCTIONS> <!-- origin-managed --> Origin: Session tracking active — prompts, files, and tokens will be captured. </INSTRUCTIONS>',
+        },
+      },
+      {
+        type: 'user',
+        message: { role: 'user', content: 'make some changes and commit' },
+      },
+    ]);
+    const parsed = parseTranscript(file);
+    expect(parsed.prompts).toEqual(['make some changes and commit']);
+  });
+
+  it('drops a user message containing only the origin-managed marker (Claude Code path)', () => {
+    const file = writeJsonl([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: 'wrapper\n<!-- origin-managed -->\nOrigin: Session tracking active\n<!-- origin-managed -->\nmore wrapper',
+        },
+      },
+    ]);
+    const parsed = parseTranscript(file);
+    expect(parsed.prompts).toEqual([]);
+  });
+
+  it('strips the <INSTRUCTIONS> envelope but keeps any real text outside it', () => {
+    const file = writeJsonl([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: 'fix the failing test\n<INSTRUCTIONS>system stuff</INSTRUCTIONS>',
+        },
+      },
+    ]);
+    const parsed = parseTranscript(file);
+    expect(parsed.prompts).toEqual(['fix the failing test']);
+  });
+
+  it('keeps a normal prompt that has no envelope at all', () => {
+    const file = writeJsonl([
+      {
+        type: 'user',
+        message: { role: 'user', content: 'add a dark mode toggle' },
+      },
+    ]);
+    const parsed = parseTranscript(file);
+    expect(parsed.prompts).toEqual(['add a dark mode toggle']);
+  });
+});

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -1,10 +1,10 @@
 // AUTO-GENERATED at build time by scripts/write-build-info.cjs.
 // Do not edit by hand. This file is gitignored.
 export const BUILD_INFO = {
-  "version": "0.20260508.1613",
-  "gitSha": "efc1e83d2f43f8549e27c66714e59cf90d8399ec",
-  "gitShortSha": "efc1e83d2f43",
-  "gitBranch": "sync-rich-context-notes",
+  "version": "0.20260509.2039",
+  "gitSha": "fe77117d7229615d4926c9b5113d4c22715adc99",
+  "gitShortSha": "fe77117d7229",
+  "gitBranch": "fix-codex-agents-md-prompt-leak",
   "gitDirty": true,
-  "builtAt": "2026-05-08T20:14:05.364Z"
+  "builtAt": "2026-05-09T00:41:44.680Z"
 } as const;

--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -2220,8 +2220,14 @@ async function handleUserPromptSubmit(input: Record<string, any>, agentSlug?: st
   }
 
   const rawPrompt = input.prompt || '';
+  // If the raw prompt contains the literal Origin-managed marker, it's our own
+  // AGENTS.md / CLAUDE.md content round-tripping through the agent (Codex
+  // reads AGENTS.md natively and re-emits it as the first user turn). Drop
+  // outright — it is never a real user input.
+  const isOriginManagedEcho = rawPrompt.includes('<!-- origin-managed -->') ||
+    /^#\s+AGENTS\.md instructions for /m.test(rawPrompt);
   // Filter out system/hook messages and internal agent tags that aren't real user prompts
-  const prompt = rawPrompt
+  const prompt = isOriginManagedEcho ? '' : rawPrompt
     .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '')
     .replace(/<task-notification>[\s\S]*?<\/task-notification>/g, '')
     .replace(/<task-id>[\s\S]*?<\/task-id>/g, '')
@@ -2233,6 +2239,10 @@ async function handleUserPromptSubmit(input: Record<string, any>, agentSlug?: st
     .replace(/<command-message>[\s\S]*?<\/command-message>/g, '')
     .replace(/<command-args>[\s\S]*?<\/command-args>/g, '')
     .replace(/<local-command-[^>]*>[\s\S]*?<\/local-command-[^>]*>/g, '')
+    // Codex wraps AGENTS.md context in <INSTRUCTIONS>...</INSTRUCTIONS> on
+    // its first user turn. Strip the envelope so any actual user text that
+    // follows still makes it through.
+    .replace(/<INSTRUCTIONS>[\s\S]*?<\/INSTRUCTIONS>/g, '')
     .trim();
   const isSystemMsg = !prompt || /^Stop hook feedback:|^Stop:Callback hook blocking error|^PostToolUse:.*hook|^PreToolUse:.*hook/i.test(prompt);
   if (prompt && !isSystemMsg) {

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -237,6 +237,12 @@ function extractUserPrompt(entry: TranscriptLine): string | null {
 }
 
 function cleanPrompt(text: string): string | null {
+  // Drop entirely if this is our own AGENTS.md / CLAUDE.md echoing back from
+  // the agent (Codex reads AGENTS.md natively and bundles it into the first
+  // user turn — looked like a real prompt in the dashboard).
+  if (text.includes('<!-- origin-managed -->') || /^#\s+AGENTS\.md instructions for /m.test(text)) {
+    return null;
+  }
   // Strip IDE-injected context tags (like Entire does)
   let cleaned = text
     .replace(/<ide_opened_file>[\s\S]*?<\/ide_opened_file>/g, '')
@@ -250,6 +256,10 @@ function cleanPrompt(text: string): string | null {
     .replace(/<tool-use-id>[\s\S]*?<\/tool-use-id>/g, '')
     .replace(/<output-file>[\s\S]*?<\/output-file>/g, '')
     .replace(/<command-name>[\s\S]*?<\/command-name>/g, '')
+    // Codex wraps AGENTS.md context in <INSTRUCTIONS>...</INSTRUCTIONS> on
+    // its first user turn. Strip the envelope so real text that follows
+    // (if any) still makes it through.
+    .replace(/<INSTRUCTIONS>[\s\S]*?<\/INSTRUCTIONS>/g, '')
     .trim();
 
   if (!cleaned) return null;


### PR DESCRIPTION
Mirrors [opsworks-co/origin#12](https://github.com/opsworks-co/origin/pull/12) (already merged).

## What it fixes

Codex reads AGENTS.md natively and re-emits its content as the first \`role: user\` turn, wrapped in \`<INSTRUCTIONS>...</INSTRUCTIONS>\`. That envelope was leaking through Origin's prompt-cleaner and showing up as a fake first prompt in the dashboard — the content of which was, ironically, our own \`<!-- origin-managed -->\` session-tracking notice.

## Fix

- \`handleUserPromptSubmit\`: drop outright if raw prompt contains the literal \`<!-- origin-managed -->\` marker; strip \`<INSTRUCTIONS>...</INSTRUCTIONS>\` blocks for the case where real text follows.
- \`cleanPrompt\` (transcript parser): same checks at parser layer.
- New \`prompt-cleanup.test.ts\` (4 cases). 242/242 pass.
- Bumps to \`0.20260509.2039\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)